### PR TITLE
Enabled TGTKCanvas + added Harfbuff include for Pango

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # gtk.mod
 GTK+3 MaxGUI Collection
+
+# Ubuntu Install
+
+gtk3webkitgtk.mod depends on libwebkitgtk-3.0-dev.
+
+gtk3maxgui.mod depends on libpango1.0-dev which now depends on libharfbuzz-dev.
+
+gtk3webkitgtk.mod depends on libpng12-0. Ubuntu has removed this from their repository, to fix:
+```
+sudo add-apt-repository ppa:linuxuprising/libpng12
+sudo apt update
+sudo apt install libpng12-0
+```
+

--- a/examples/createcanvas.bmx
+++ b/examples/createcanvas.bmx
@@ -1,0 +1,56 @@
+SuperStrict
+' createcanvas.bmx
+
+Framework gtk.gtk3maxgui
+Import brl.eventqueue
+?bmxng
+Import brl.timerdefault
+?Not bmxng
+Import brl.timer
+?
+Import brl.max2d
+Import brl.glmax2d
+
+Global GAME_WIDTH%=320
+Global GAME_HEIGHT%=240
+
+' create a centered window with client size GAME_WIDTH,GAME_HEIGHT
+
+Local wx%=(ClientWidth(Desktop())-GAME_WIDTH)/2
+Local wy%=(ClientHeight(Desktop())-GAME_HEIGHT)/2
+
+Local window:TGadget=CreateWindow("My Canvas",wx,wy,GAME_WIDTH,GAME_HEIGHT,Null,WINDOW_TITLEBAR)'|WINDOW_CLIENTCOORDS)
+
+' create a canvas for our game
+Local canvas:TGadget=CreateCanvas(0,0,320,240,window)
+
+' create an update timer
+
+CreateTimer 60
+
+While WaitEvent()
+	Select EventID()
+		Case EVENT_TIMERTICK
+			RedrawGadget canvas
+
+		Case EVENT_GADGETPAINT
+			SetGraphics CanvasGraphics(canvas)
+			SetOrigin 160,120
+			SetLineWidth 5
+			Cls
+			Local t%=MilliSecs()
+			DrawLine 0,0,120*Cos(t),120*Sin(t)
+			DrawLine 0,0,80*Cos(t/60),80*Sin(t/60)
+			Flip
+
+		Case EVENT_MOUSEMOVE
+			Print "MOVE!"
+
+		Case EVENT_WINDOWCLOSE
+			FreeGadget canvas
+			End
+
+		Case EVENT_APPTERMINATE
+			End
+	End Select
+Wend

--- a/examples/createhtmlview.bmx
+++ b/examples/createhtmlview.bmx
@@ -14,7 +14,7 @@ window = CreateWindow("My Window",30,20,600,440,,15|WINDOW_ACCEPTFILES)
 htmlview = CreateHTMLView(0,0,ClientWidth(window),ClientHeight(window),window)
 SetGadgetLayout htmlview,1,1,1,1 
 
-HtmlViewGo htmlview,"www.blitzmax.com"
+HtmlViewGo htmlview,"www.blitzmax.org"
 
 While WaitEvent()
 	Print CurrentEvent.ToString()

--- a/gtk3maxgui.mod/gtk3maxgui.bmx
+++ b/gtk3maxgui.mod/gtk3maxgui.bmx
@@ -37,6 +37,7 @@ ModuleInfo "CC_OPTS: -I/usr/include/gtk-3.0  -I/usr/lib/i386-linux-gnu/gtk-3.0/i
 ModuleInfo "CC_OPTS: -I/usr/include/cairo"
 ' pango
 ModuleInfo "CC_OPTS: -I/usr/include/pango-1.0"
+ModuleInfo "CC_OPTS: -I/usr/include/harfbuzz"
 ' gdk
 ModuleInfo "CC_OPTS: -I/usr/include/gdk-pixbuf-2.0"
 ' atk

--- a/gtk3maxgui.mod/gtkcommon.bmx
+++ b/gtk3maxgui.mod/gtkcommon.bmx
@@ -171,6 +171,9 @@ Extern
 	' gdk pango
 	Function gdk_pango_context_get:Byte Ptr()
 	
+	' gtkcanvas
+	Function gdk_x11_window_get_xid:Byte Ptr(handle:Byte Ptr)
+	
 	' gtkwindow
 	Function gtk_window_new:Byte Ptr(_type:Int)
 	Function gtk_window_move(handle:Byte Ptr, x:Int, y:Int)

--- a/gtk3maxgui.mod/gtkgadget.bmx
+++ b/gtk3maxgui.mod/gtkgadget.bmx
@@ -117,10 +117,8 @@ Type TGTKGadget Extends TGadget
 				gadget = TGTKListbox.CreateListBox(x, y ,w , h, label, group, style)
 			Case GTK_TREEVIEW
 				gadget = TGTKTreeView.CreateTreeView(x, y ,w , h, label, group, style)
-Rem 
 			Case GTK_CANVAS
 				gadget = TGTKCanvas.CreateCanvas(x, y ,w , h, label, group, style)
-End Rem
 		End Select
 
 		' map the new gadget - so we can find it later if required
@@ -4586,7 +4584,6 @@ End Type
 Rem
 bbdoc: A canvas.
 End Rem
-Rem 
 Type TGTKCanvas Extends TGTKGadget
 
 	Field canvas:TGraphics
@@ -4618,22 +4615,22 @@ Type TGTKCanvas Extends TGTKGadget
 		' we need to handle our own redrawing...
 		'gtk_widget_set_double_buffered(handle, False)
 
-		addConnection("expose_event", g_signal_cb3(handle, "expose_event", CanvasRedraw, Self, Destroy, 0))
+		addConnection("draw", g_signal_cb3(handle, "draw", CanvasRedraw, Self, Destroy, 0))
 
 		gtk_widget_add_events(handle, GDK_BUTTON_PRESS_MASK | ..
 			GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | ..
 			GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_POINTER_MOTION_MASK | GDK_SCROLL_MASK)' | ..
 '				GDK_POINTER_MOTION_HINT_MASK)
 
-		addConnection("button-press-event", g_signal_cb3(handle, "button-press-event", OnMouseDown, Self, Destroy, 0))
-		addConnection("button-release-event", g_signal_cb3(handle, "button-release-event", OnMouseUp, Self, Destroy, 0))
-		addConnection("enter-notify-event", g_signal_cb3(handle, "enter-notify-event", OnMouseEnter, Self, Destroy, 0))
-		addConnection("leave-notify-event", g_signal_cb3(handle, "leave-notify-event", OnMouseLeave, Self, Destroy, 0))
-		addConnection("motion-notify-event", g_signal_cb3(handle, "motion-notify-event", OnMouseMove, Self, Destroy, 0))
+		addConnection("button-press-event", g_signal_cb3_ret(handle, "button-press-event", OnMouseDown, Self, Destroy, 0))
+		addConnection("button-release-event", g_signal_cb3_ret(handle, "button-release-event", OnMouseUp, Self, Destroy, 0))
+		addConnection("enter-notify-event", g_signal_cb3_ret(handle, "enter-notify-event", OnMouseEnter, Self, Destroy, 0))
+		addConnection("leave-notify-event", g_signal_cb3_ret(handle, "leave-notify-event", OnMouseLeave, Self, Destroy, 0))
+		addConnection("motion-notify-event", g_signal_cb3_ret(handle, "motion-notify-event", OnMouseMove, Self, Destroy, 0))
 		addConnection("scroll-event", g_signal_cb3(handle, "scroll-event", OnScroll, Self, Destroy, 0))
 
-		addConnection("key-press-event", g_signal_cb3(handle, "key-press-event", OnKeyDown, Self, Destroy, 0))
-		addConnection("key-release-event", g_signal_cb3(handle, "key-release-event", OnKeyUp, Self, Destroy, 0))
+		addConnection("key-press-event", g_signal_cb3_ret(handle, "key-press-event", OnKeyDown, Self, Destroy, 0))
+		addConnection("key-release-event", g_signal_cb3_ret(handle, "key-release-event", OnKeyUp, Self, Destroy, 0))
 
 		SetShow(True)
 	End Method
@@ -4648,7 +4645,7 @@ Type TGTKCanvas Extends TGTKGadget
 
 	Method CanvasGraphics:TGraphics()
 		If Not canvas Then
-			canvas = BRL.Graphics.AttachGraphics(gdk_x11_drawable_get_xid(gtk_widget_get_window(handle)), Mode)
+			canvas = BRL.Graphics.AttachGraphics(gdk_x11_window_get_xid(gtk_widget_get_window(handle)), Mode)
 		End If
 
 		Return canvas
@@ -4788,7 +4785,6 @@ Type TGTKCanvas Extends TGTKGadget
 		handle = Null
 	End Method
 End Type
-End Rem
 
 Rem
 bbdoc: A text area.

--- a/gtk3maxgui.mod/gtkgui.bmx
+++ b/gtk3maxgui.mod/gtkgui.bmx
@@ -550,10 +550,8 @@ Type TGTK3GUIDriver Extends TMaxGUIDriver
 				gtkclass = GTK_PROGRESSBAR
 			Case GADGET_MENUITEM
 				gtkclass = GTK_MENUITEM
-Rem 
 			Case GADGET_CANVAS
 				gtkclass = GTK_CANVAS
-End Rem
 		End Select
 
 		gtkgroup = TGTKGadget(group)

--- a/maxguitextareascintilla.mod/maxguitextareascintilla.bmx
+++ b/maxguitextareascintilla.mod/maxguitextareascintilla.bmx
@@ -48,6 +48,7 @@ ModuleInfo "CC_OPTS: -I/usr/include/gtk-3.0  -I/usr/lib/i386-linux-gnu/gtk-3.0/i
 ModuleInfo "CC_OPTS: -I/usr/include/cairo"
 ' pango
 ModuleInfo "CC_OPTS: -I/usr/include/pango-1.0"
+ModuleInfo "CC_OPTS: -I/usr/include/harfbuzz"
 ' gdk
 ModuleInfo "CC_OPTS: -I/usr/include/gdk-pixbuf-2.0"
 ' atk


### PR DESCRIPTION
This is Derron's fix to TGTKCanvas. Thanks Ron! 

Added the Harfbuzz include for the latest Pango already applied to maxgui.mod.

I also added examples/createcanvas.bmx. Hopefuly you don't mind that I added some Ubuntu dependency info to README.md.

Tested and working. Fixes maxgui.mod issue #28 https://github.com/bmx-ng/maxgui.mod/issues/28